### PR TITLE
Add permissions for references and pre-inscriptions; update RoleSeede…

### DIFF
--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -25,5 +25,16 @@ class RoleSeeder extends Seeder
 
         $adminRole = Role::findByName('Administrador');
         $adminRole->givePermissionTo(Permission::all());
+
+        $controllerRole = Role::findByName('Controller');
+        $controllerPermissions = Permission::whereIn('key', [
+            'reference:view',
+            'reference:edit',
+            'reference:update',
+            'pre-inscription:view',
+            'pre-inscription:edit',
+            'pre-inscription:update'
+        ])->get();
+        $controllerRole->givePermissionTo($controllerPermissions);
     }
 }

--- a/database/seeders/data/permissions.json
+++ b/database/seeders/data/permissions.json
@@ -81,12 +81,36 @@
         "name": "ver referencias",
         "description": "Permite ver la lista de referencias",
         "category": "Gestion de referencias",
-        "key": "reference:show"
+        "key": "reference:view"
     },
     {
         "name": "editar referencias",
         "description": "Permite actualizar el estado de una referencia",
         "category": "Gestion de referencias",
         "key": "reference:edit"
+    },
+    {
+        "name": "actualizar referencias",
+        "description": "Permite actualizar los datos de una referencia sin cambiar su estado",
+        "category": "Gestion de referencias",
+        "key": "reference:update"
+    },
+    {
+        "name": "ver pre-inscripciones",
+        "description": "Permite ver la lista de pre-inscripciones",
+        "category": "Gestión de Pre-Inscripciones",
+        "key": "pre-inscription:view"
+    },
+    {
+        "name": "editar pre-inscripciones",
+        "description": "Permite editar pre-inscripciones existentes",
+        "category": "Gestión de Pre-Inscripciones",
+        "key": "pre-inscription:edit"
+    },
+    {
+        "name": "actualizar pre-inscripciones",
+        "description": "Permite actualizar los datos de una pre-inscripción sin cambiar su estado",
+        "category": "Gestión de Pre-Inscripciones",
+        "key": "pre-inscription:update"
     }
 ]

--- a/resources/js/lib/consts/navItems.ts
+++ b/resources/js/lib/consts/navItems.ts
@@ -1,5 +1,5 @@
 import { NavItem } from '@/types';
-import { BookOpen, LayoutGrid, Notebook, Shield } from 'lucide-react';
+import { BookOpen, LayoutGrid, ListPlus, Notebook, Shield } from 'lucide-react';
 
 export const mainNavItems: NavItem[] = [
     {
@@ -23,7 +23,13 @@ export const mainNavItems: NavItem[] = [
         title: 'Referencias',
         href: '/references',
         icon: Notebook,
-        permissions: ['reference:create', 'reference:edit']
+        permissions: ['reference:view', 'reference:edit', 'reference:update']
+    },
+    {
+        title: 'Pre-Inscripciones',
+        href: '/pre-inscription',
+        icon: ListPlus,
+        permissions: ['pre-inscription:update', 'pre-inscription:edit', 'pre-inscription:view'],
     }
 ];
 


### PR DESCRIPTION
This pull request introduces new roles and permissions for managing references and pre-inscriptions, updates existing permission keys, and expands the navigation menu to reflect these changes. The most important changes are grouped into role and permission management, and UI updates.

### Role and Permission Management:

* [`database/seeders/RoleSeeder.php`](diffhunk://#diff-c93cca45462b8a8acc5ad4e48337d950f732fe59db7de49a59cff168b1762386R28-R38): Added a new role, `Controller`, and assigned it permissions related to references and pre-inscriptions.
* [`database/seeders/data/permissions.json`](diffhunk://#diff-d7fdcbde67d7530ba52c2a5ebf61c964e31cdb6eba7c11541f39cdb6b9aae12cL84-R114): Updated the `reference:show` permission key to `reference:view` and added new permissions for managing references (`reference:update`) and pre-inscriptions (`pre-inscription:view`, `pre-inscription:edit`, `pre-inscription:update`).

### UI Updates:

* [`resources/js/lib/consts/navItems.ts`](diffhunk://#diff-e128ed4fffe25ff083a52bb509f764bbfeb29deadb8c00cfe3553090e0de8b37L26-R32): Added a new navigation item for "Pre-Inscripciones" with associated permissions and updated the "Referencias" item to include the new `reference:view` and `reference:update` permissions.
* [`resources/js/lib/consts/navItems.ts`](diffhunk://#diff-e128ed4fffe25ff083a52bb509f764bbfeb29deadb8c00cfe3553090e0de8b37L2-R2): Imported the `ListPlus` icon to represent the "Pre-Inscripciones" navigation item.…r and navItems