### PR TITLE
Add route for creating inscription reference

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,9 @@ Route::get('/', function () {
     return Inertia::render('welcome');
 })->name('home');
 
+Route::get('inscription-reference', [PreInscriptionController::class, 'create'])
+    ->name('inscription-reference');
+
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('dashboard', [ReferenceController::class, 'dashboard'])->name('dashboard');
 


### PR DESCRIPTION
This pull request introduces a new route in the `routes/web.php` file to handle a pre-inscription reference page. 

Routing changes:

* Added a new route `inscription-reference` that maps to the `create` method of the `PreInscriptionController` class. This route is named `inscription-reference`.