### PR TITLE
Bugfix/handle unique mail preinsciption

### DIFF
--- a/app/Http/Controllers/ReferenceController.php
+++ b/app/Http/Controllers/ReferenceController.php
@@ -84,7 +84,6 @@ class ReferenceController extends Controller
                 ->withInput();
         } catch (\Exception $e) {
             return back()
-                ->with(['step' => 2])
                 ->withErrors(['error' => $e->getMessage()])
                 ->withInput();
         }


### PR DESCRIPTION
This pull request introduces significant updates to the `PreInscriptionController` to handle email validation and improve error messaging, while also removing unused functionality. Additionally, there is a minor cleanup in the `ReferenceController`. Below is a summary of the most important changes:

### Enhancements to Email Validation and Messaging
* Added a new private method `checkEmailPreInscription` in `PreInscriptionController` to validate if an email already exists in pre-inscriptions and return a custom message based on its status. This includes handling cases for pending, rejected (with gender-specific messaging), and other scenarios.
* Updated the `store` method in `PreInscriptionController` to incorporate the new email validation logic. If the email exists, the user is redirected with a relevant success message and query parameters.

### Codebase Simplification
* Removed the unused `convertNamesToIds` private method in `PreInscriptionController`, which was responsible for converting country and stake names to IDs.

### Minor Cleanup
* Removed the redundant `with(['step' => 2])` call in the `store` method of `ReferenceController` to simplify the error handling logic.