### PR TITLE
Bugfix/back to action selection

### DIFF
--- a/resources/js/components/pre-registration/steps/ActionSelectionStep.tsx
+++ b/resources/js/components/pre-registration/steps/ActionSelectionStep.tsx
@@ -87,7 +87,7 @@ export function ActionSelectionStep() {
               className={`min-w-[140px] bg-[rgb(46_131_242_/_1)] text-white hover:shadow-lg hover:bg-[rgb(46_131_242_/_1)]/90 ${!action && 'opacity-50 cursor-not-allowed'}`}
             >
               <Link
-                href={`${action}?step=2`}
+                href={`${action}?step=2&full=true`}
                 tabIndex={!action ? -1 : 0}
                 aria-disabled={!action}
               >

--- a/resources/js/components/pre-registration/steps/PreRegistrationFormStep.tsx
+++ b/resources/js/components/pre-registration/steps/PreRegistrationFormStep.tsx
@@ -44,10 +44,17 @@ export function PreRegistrationFormStep({ countries = [], stakes = [], request }
         }
         nextStep();
     }
-    const phoneCode = () => {
-        const selectedCountry = countries.find(c => c.id === data.country_id);
-        return `${selectedCountry?.code} (${selectedCountry?.phone_code})` || "+1 (USA)"
+
+    const isFull = new URLSearchParams(window.location.search).get('full') === 'true';
+
+    const handleBack = () => {
+        if (isFull) {
+            window.history.back();
+        } else {
+            previousStep();
+        }
     }
+
     return (
         <div className="mx-auto max-w-3xl">
             <Card className="border-2">
@@ -273,7 +280,7 @@ export function PreRegistrationFormStep({ countries = [], stakes = [], request }
 
                         {/* Botones */}
                         <div className="flex justify-between pt-4">
-                            <Button type="button" onClick={previousStep} variant="outline" size="lg" className="min-w-[120px]">
+                            <Button type="button" onClick={handleBack} variant="outline" size="lg" className="min-w-[120px]">
                                 <ArrowLeft className="mr-2 h-4 w-4" />
                                 Anterior
                             </Button>

--- a/resources/js/components/pre-registration/steps/ReferralFormStep.tsx
+++ b/resources/js/components/pre-registration/steps/ReferralFormStep.tsx
@@ -40,6 +40,18 @@ export function ReferralFormStep({ stakes, countries, request, }: ReferralFormSt
   const { enums } = usePage<{ enums: Enums }>().props;
 
   const [errors, setErrors] = useState<Record<string, string>>({});
+  // obtener query param full
+
+  const isFull = new URLSearchParams(window.location.search).get('full') === 'true';
+
+  const handleBack = () => {
+    if (isFull) {
+      window.history.back();
+    } else {
+      previousStep();
+    }
+  }
+
   const filteredStakes = data.country_id ?
     stakes.filter(stake => stake.country_id === data.country_id) :
     [{ id: 0, name: 'Selecciona un país primero', country_id: 0 }];
@@ -241,7 +253,7 @@ export function ReferralFormStep({ stakes, countries, request, }: ReferralFormSt
             <div className="flex justify-between pt-4">
               <Button
                 type="button"
-                onClick={previousStep}
+                onClick={handleBack}
                 variant="outline"
                 size="lg"
                 className="min-w-[120px]"


### PR DESCRIPTION
This pull request introduces enhancements to the navigation flow in the pre-registration steps by adding support for a `full` query parameter. This parameter changes the behavior of the "Back" button to either navigate to the previous step or use browser history, depending on the context. The changes also include updates to the `href` attributes in links to include the `full` parameter.

### Navigation flow updates:

* [`resources/js/components/pre-registration/steps/ActionSelectionStep.tsx`](diffhunk://#diff-aea17aecbb2198687f9fd2829cfd5150131b8db7217ac04831d51432da150f28L90-R90): Updated the `href` attribute in the `Link` component to append the `full=true` query parameter, ensuring consistent navigation behavior.
* [`resources/js/components/pre-registration/steps/PreRegistrationFormStep.tsx`](diffhunk://#diff-5e81c861542520b2c809c74be3b94005102c3f14f85ef71fe3dcd87da05952faL47-R57): Added a new `isFull` variable to detect the `full` query parameter and implemented a `handleBack` function to conditionally navigate using browser history or the previous step. Updated the "Back" button to use `handleBack` instead of `previousStep`. [[1]](diffhunk://#diff-5e81c861542520b2c809c74be3b94005102c3f14f85ef71fe3dcd87da05952faL47-R57) [[2]](diffhunk://#diff-5e81c861542520b2c809c74be3b94005102c3f14f85ef71fe3dcd87da05952faL276-R283)
* [`resources/js/components/pre-registration/steps/ReferralFormStep.tsx`](diffhunk://#diff-13a43cf35f91d4ddf04f704181be6cb84dc1959e1c3234b5970e20f483fb88caR43-R54): Introduced the same `isFull` variable and `handleBack` function as in `PreRegistrationFormStep`. Updated the "Back" button to use `handleBack` for consistent navigation behavior. [[1]](diffhunk://#diff-13a43cf35f91d4ddf04f704181be6cb84dc1959e1c3234b5970e20f483fb88caR43-R54) [[2]](diffhunk://#diff-13a43cf35f91d4ddf04f704181be6cb84dc1959e1c3234b5970e20f483fb88caL244-R256)