### PR TITLE
Feature/update action descriptions for clarity in pre-registration step

### DIFF
--- a/resources/js/components/pre-registration/steps/ActionSelectionStep.tsx
+++ b/resources/js/components/pre-registration/steps/ActionSelectionStep.tsx
@@ -43,7 +43,7 @@ export function ActionSelectionStep() {
                   <div className="flex-1">
                     Referir a un amigo
                     <p className="text-sm text-muted-foreground mt-1">
-                      Recomienda a alguien que conozcas para que participe de nuestros programas de capacitación
+                      Recomienda a alguien que conozcas para que participe de nuestros programas de capacitación para el empleo.
                     </p>
                   </div>
                 </div>
@@ -58,9 +58,9 @@ export function ActionSelectionStep() {
                     <UserPlus className="h-6 w-6 text-[rgb(46_131_242_/_1)]" />
                   </div>
                   <div className="flex-1">
-                    Pre-inscribirme al curso
+                    Preinscribirme al curso
                     <p className="text-sm text-muted-foreground mt-1">
-                      Completa tu pre-inscripción para participar en nuestros programas
+                      Completa tu preinscripción para participar en nuestros programas de capacitación para el empleo.
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
This pull request includes minor text updates to improve clarity and consistency in the `ActionSelectionStep` component. The changes focus on refining the wording for better readability and aligning terminology.

Text updates for clarity and consistency:

* Updated the description for referring a friend to specify "programas de capacitación para el empleo" instead of the more general "programas de capacitación." (`resources/js/components/pre-registration/steps/ActionSelectionStep.tsx`, [resources/js/components/pre-registration/steps/ActionSelectionStep.tsxL46-R46](diffhunk://#diff-aea17aecbb2198687f9fd2829cfd5150131b8db7217ac04831d51432da150f28L46-R46))
* Standardized the term "preinscripción" by removing the hyphen and updated the description to include "programas de capacitación para el empleo" for consistency. (`resources/js/components/pre-registration/steps/ActionSelectionStep.tsx`, [resources/js/components/pre-registration/steps/ActionSelectionStep.tsxL61-R63](diffhunk://#diff-aea17aecbb2198687f9fd2829cfd5150131b8db7217ac04831d51432da150f28L61-R63))