### PR TITLE
Fix response handling in useFilteredStakes to correctly dispatch fetc…

### DIFF
--- a/resources/js/hooks/use-filtered-stakes.tsx
+++ b/resources/js/hooks/use-filtered-stakes.tsx
@@ -76,8 +76,8 @@ const useFilteredStakes = (country_id: number) => {
                 const data = await response.json();
 
                 // Verificar la estructura de la respuesta
-                if (data.status === 'success' && Array.isArray(data.data)) {
-                    dispatch({ type: 'FETCH_SUCCESS', payload: data.data });
+                if (data.status === 'success' && Array.isArray(data.stakes)) {
+                    dispatch({ type: 'FETCH_SUCCESS', payload: data.stakes });
                 } else {
                     throw new Error('Invalid response format');
                 }


### PR DESCRIPTION
This pull request makes a small change to the `useFilteredStakes` hook to correctly handle the structure of the API response. The hook now expects the list of stakes to be under the `stakes` property instead of `data`, ensuring the fetched data is dispatched properly.…hed stakes