### PR TITLE
fix: ensure status validation checks for existence before comparison …

### DIFF
--- a/app/Http/Controllers/PreInscriptionController.php
+++ b/app/Http/Controllers/PreInscriptionController.php
@@ -123,7 +123,7 @@ class PreInscriptionController extends Controller
 
             $validated = $request->validate($rules);
 
-            if ($validated['status'] === RequestStatusEnum::APPROVED->value) {
+            if (isset($validated['status']) && $validated['status'] === RequestStatusEnum::APPROVED->value) {
                 $validated['declined_reason'] = null;
             }
             $preInscription =  PreInscription::create($validated);


### PR DESCRIPTION
This pull request makes a small improvement to the `store` method in the `PreInscriptionController`. It adds a check to ensure that the `status` field exists in the validated data before comparing its value, which helps prevent potential errors if `status` is missing.