### PR TITLE
Feature/undo soft delete

### DIFF
--- a/app/Http/Controllers/CountryController.php
+++ b/app/Http/Controllers/CountryController.php
@@ -145,7 +145,7 @@ class CountryController extends Controller
             $country->save();
 
             return redirect()->route('countries.index')
-                ->with('success', 'Country deleted successfully.');
+                ->with('success', 'Pais eliminado exitosamente.');
         } catch (\Exception $e) {
             return redirect()->back()
                 ->withErrors(['error' => 'Failed to delete country: ' . $e->getMessage()]);

--- a/app/Http/Controllers/CountryController.php
+++ b/app/Http/Controllers/CountryController.php
@@ -90,7 +90,6 @@ class CountryController extends Controller
             return redirect()->route('countries.index')
                 ->with('success', 'Pais creado exitosamente.');
 
-                ->with('success', 'Country created successfully.');
         } catch (\Exception $e) {
 
             return redirect()->back()

--- a/app/Http/Controllers/CountryController.php
+++ b/app/Http/Controllers/CountryController.php
@@ -38,6 +38,21 @@ class CountryController extends Controller
     
     public function store(Request $request)
     {
+
+        $country = Country::where('name', $request->name)->first();
+        
+        if ($country && $country->status['id'] == StatusEnum::DELETED->value) {
+            // Si el país existe pero está eliminado, restaurarlo
+            $country->status = $request->status ?? StatusEnum::ACTIVE->value;
+            $country->code = $request->code ?? $country->code;
+            $country->phone_code = $request->phone_code ?? $country->phone_code;
+            $country->flag = $request->flag ?? null;
+
+            $country->save();
+
+            return redirect()->route('countries.index')
+                ->with('success', 'Pais creado exitosamente');
+        }
          
         try {
             $validated =  $request->validate([
@@ -55,7 +70,7 @@ class CountryController extends Controller
            
 
             return redirect()->route('countries.index')
-                ->with('success', 'Country created successfully.');
+                ->with('success', 'Pais creado exitosamente.');
 
         } catch (\Exception $e) {
             

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -32,6 +32,21 @@ class CourseController extends Controller
      */
     public function store(Request $request)
     {
+        $course = course::where('name', $request->name)->first();
+
+        // dd($course->status);
+        if( $course && $course->status['id'] === StatusEnum::DELETED->value) {
+            // If the course exists but is deleted, restore it
+            $course->status = $request->status ?? StatusEnum::ACTIVE->value;
+            $course->duration = $request->duration ?? $course->duration;
+            $course->modality = $request->modality ?? $course->modality;
+
+            $course->save();
+
+            return redirect()->route('courses.index')
+                ->with('success', 'Curso restaurado exitosamente');
+        }
+
         try {
             $validated =  $request->validate([
                 'name' => 'required|string|max:255|unique:courses,name',

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -102,7 +102,7 @@ class CourseController extends Controller
             $course->update($validated);
             $course->save();
             return redirect()->route('courses.index')
-                ->with('success', 'Course updated successfully.');
+                ->with('success', 'Curso actualizado exitosamente.');
         } catch (\Exception $e) {
             return redirect()->back()
                 ->withErrors(['error' => $e->getMessage()])
@@ -122,7 +122,7 @@ class CourseController extends Controller
             $course->save();
 
             return redirect()->route('courses.index')
-                ->with('success', 'Course deleted successfully.');
+                ->with('success', 'Curso eliminado exitosamente.');
         } catch (\Exception $e) {
             return redirect()->back()
                 ->withErrors(['error' => 'Failed to delete course: ' . $e->getMessage()]);

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -63,7 +63,7 @@ class CourseController extends Controller
             ]);
 
             return redirect()->route('courses.index')
-                ->with('success', 'Course created successfully.');
+                ->with('success', 'Curso restaurado exitosamente.');
         } catch (\Exception $e) {
             return redirect()->back()
                 ->withErrors(['error' => $e->getMessage()])

--- a/app/Http/Controllers/StakeController.php
+++ b/app/Http/Controllers/StakeController.php
@@ -54,7 +54,7 @@ class StakeController extends Controller
             $stake->save();
 
             return redirect()->route('stakes.index')
-                ->with('success', 'Estaca creado exitosamente');
+                ->with('success', 'Estaca creada exitosamente');
         }
             
 

--- a/app/Http/Controllers/StakeController.php
+++ b/app/Http/Controllers/StakeController.php
@@ -39,8 +39,25 @@ class StakeController extends Controller
     /**
      * Store a newly created resource in storage.
      */
+    
     public function store(Request $request)
     {
+
+        $stake = Stake::where('name', $request->name)->first();
+
+        if ($stake && $stake->status->value == StatusEnum::DELETED->value) {
+            // Si la estaca existe pero está eliminada, restaurarla
+
+            $stake->status = $request->status ?? StatusEnum::ACTIVE->value;
+            $stake->country_id = $request->country_id ?? $stake->country_id;
+            $stake->user_id = $request->user_id ?? null;
+            $stake->save();
+
+            return redirect()->route('stakes.index')
+                ->with('success', 'Stake creado exitosamente');
+        }
+            
+
         $validated = $request->validate([
             'name' => 'required|string|max:255|unique:stakes',
             'country_id' => 'required|exists:countries,id',

--- a/app/Http/Controllers/StakeController.php
+++ b/app/Http/Controllers/StakeController.php
@@ -54,7 +54,7 @@ class StakeController extends Controller
             $stake->save();
 
             return redirect()->route('stakes.index')
-                ->with('success', 'Stake creado exitosamente');
+                ->with('success', 'Estaca creado exitosamente');
         }
             
 

--- a/resources/js/components/courses/course-data-table.tsx
+++ b/resources/js/components/courses/course-data-table.tsx
@@ -44,7 +44,7 @@ export const createColumns = ({ onEditCourse, onDeleteCourse }: CourseDataTableP
     },
     {
         accessorKey: "name",
-        header: "Nombre del referido",
+        header: "Nombre del curso",
         cell: ({ row }) => {
             const course = row.original;
             return (

--- a/resources/js/components/courses/create-course.tsx
+++ b/resources/js/components/courses/create-course.tsx
@@ -62,7 +62,7 @@ export function CreateCourse() {
                                 value={data.name}
                                 onChange={(e) => setData('name', e.target.value)}
                                 required
-                                placeholder="Primer nombre"
+                                placeholder="Nombre del curso"
                             />
                             <InputError message={errors.name} />
                         </div>


### PR DESCRIPTION
This pull request introduces logic to restore soft-deleted records for countries, courses, and stakes when attempting to create new entries with the same name, rather than creating duplicates. Additionally, it updates user-facing messages to Spanish for consistency and corrects some UI text. The most important changes are grouped below:

**Restore Logic for Soft-Deleted Entities:**

* In `CountryController`, `CourseController`, and `StakeController`, added logic in the `store` methods to check if an entity with the given name exists and is marked as deleted (`StatusEnum::DELETED`). If so, the entity is restored and updated with the new data instead of creating a duplicate. [[1]](diffhunk://#diff-836a5f3c88a3e2716e602f84aa82ffa860e344e6e70e2e68e2cee7e7e6218889R59-R74) [[2]](diffhunk://#diff-7ed236bc2bc9b87c51c7a8e9ad670cb45715ec5fa2b4253ef5fbe4ae0d7ad267R51-R65) [[3]](diffhunk://#diff-2cd552bd14f53539cd046456a97e76145a5484e9a0863eeed0da1edddd1a1e2aR53-R71)

**Localization and UI Text Updates:**

* Updated all success messages in `CountryController` and `CourseController` to Spanish for create, update, and delete operations. [[1]](diffhunk://#diff-836a5f3c88a3e2716e602f84aa82ffa860e344e6e70e2e68e2cee7e7e6218889L75-R92) [[2]](diffhunk://#diff-836a5f3c88a3e2716e602f84aa82ffa860e344e6e70e2e68e2cee7e7e6218889L131-R148) [[3]](diffhunk://#diff-7ed236bc2bc9b87c51c7a8e9ad670cb45715ec5fa2b4253ef5fbe4ae0d7ad267L67-R82) [[4]](diffhunk://#diff-7ed236bc2bc9b87c51c7a8e9ad670cb45715ec5fa2b4253ef5fbe4ae0d7ad267L106-R121) [[5]](diffhunk://#diff-7ed236bc2bc9b87c51c7a8e9ad670cb45715ec5fa2b4253ef5fbe4ae0d7ad267L126-R141)
* Changed the column header in the course data table from "Nombre del referido" to "Nombre del curso" for clarity.
* Updated the placeholder in the course creation form's name input to "Nombre del curso".