### PR TITLE
Fix: update 'rejected' status translation to 'No aprobado'

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Enums\CourseModalityEnum;
 use App\Enums\StatusEnum;
-use App\Models\course;
+use App\Models\Course;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 

--- a/lang/es/enums.php
+++ b/lang/es/enums.php
@@ -34,7 +34,7 @@ return [
     'request_status' => [
         'pending' => 'Pendiente',
         'approved' => 'Aprobado',
-        'rejected' => 'Rechazado',
+        'rejected' => 'No aprobado',
     ],
     'reference_status' => [
         'pending' => 'Pendiente',


### PR DESCRIPTION
This pull request updates the Spanish translation for the "rejected" status in the `request_status` enum to use a more accurate or user-friendly term.

- Localization update:
  * Changed the value for `'rejected'` in the `request_status` array from `'Rechazado'` to `'No aprobado'` in `lang/es/enums.php`