### PR TITLE
Fix: update 'rejected' status translation to 'No aprobado' (#70)

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Enums\CourseModalityEnum;
 use App\Enums\StatusEnum;
-use App\Models\course;
+use App\Models\Course;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 

--- a/lang/es/enums.php
+++ b/lang/es/enums.php
@@ -34,7 +34,7 @@ return [
     'request_status' => [
         'pending' => 'Pendiente',
         'approved' => 'Aprobado',
-        'rejected' => 'Rechazado',
+        'rejected' => 'No aprobado',
     ],
     'reference_status' => [
         'pending' => 'Pendiente',


### PR DESCRIPTION
This pull request introduces a minor fix and a small language update. The most notable changes are:

Code cleanup:

* Fixed the casing of the `Course` model import in `CourseController.php` to match the actual class name.

Localization update:

* Updated the Spanish translation for the `request_status.rejected` enum from "Rechazado" to "No aprobado" in `lang/es/enums.php`.* Fix: update 'rejected' status translation to 'No aprobado'

* Fix: correct casing of 'Course' model import in CourseController