### PR TITLE
Bugfix/permission errors

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Enums\CourseModalityEnum;
 use App\Enums\StatusEnum;
-use App\Models\course;
+use App\Models\Course;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 
@@ -51,7 +51,7 @@ class CourseController extends Controller
         $course = course::where('name', $request->name)->first();
 
         // dd($course->status);
-        if( $course && $course->status['id'] === StatusEnum::DELETED->value) {
+        if ($course && $course->status['id'] === StatusEnum::DELETED->value) {
             // If the course exists but is deleted, restore it
             $course->status = $request->status ?? StatusEnum::ACTIVE->value;
             $course->duration = $request->duration ?? $course->duration;

--- a/app/Http/Controllers/PreInscriptionController.php
+++ b/app/Http/Controllers/PreInscriptionController.php
@@ -390,17 +390,20 @@ class PreInscriptionController extends Controller
     {
         try {
             $user = Auth::user();
-            $query = PreInscription::query()->with(['country', 'stake']);
 
-            if ($user->hasRole('Responsable') && !$user->hasRole('Administrador')) {
-                $stakesIds = Stake::where('user_id', $user->id)->pluck('id');
-                $query->whereIn('stake_id', $stakesIds);
+            $all = $user->can('ver todas las preinscripciones');
+            $own = $user->can('ver preinscripciones propias');
+            $staff = $user->can('ver preinscripciones del personal');
+
+            if (!$all && !$own && !$staff) {
+                return back()->with('forbidden', 'No tienes permiso para realizar esta acción. Si crees que esto es un error, contacta al administrador del sistema.');
             }
+
+            $query = PreInscription::query()->with(['country', 'stake']);
 
             $preInscriptions = $query->get();
             $total = $preInscriptions->count();
 
-            // General statistics
             $pending = $preInscriptions->where('status.id', RequestStatusEnum::PENDING->value)->count();
             $accepted = $preInscriptions->where('status.id', RequestStatusEnum::APPROVED->value)->count();
             $rejected = $preInscriptions->where('status.id', RequestStatusEnum::REJECTED->value)->count();

--- a/app/Http/Controllers/PreInscriptionController.php
+++ b/app/Http/Controllers/PreInscriptionController.php
@@ -87,7 +87,7 @@ class PreInscriptionController extends Controller
             $preInscriptions = $query->paginate($perPage, ['*'], 'page', $page);
 
             $responsables = !$all ? null :
-                User::role('Responsable')
+                User::permission('recibir asignaciones de estacas')
                 ->get()
                 ->map(fn($u) => [
                     'id' => $u->id,
@@ -304,7 +304,7 @@ class PreInscriptionController extends Controller
             $preInscription->save();
 
             return redirect()->back()
-                ->with('success', 'Pre-inscripción actualizada exitosamente');
+                ->with('success', 'Preinscripción actualizada exitosamente');
         } catch (ValidationException $e) {
             return back()
                 ->withErrors($e->errors())
@@ -372,7 +372,7 @@ class PreInscriptionController extends Controller
 
             return response()->json([
                 'success' => true,
-                'message' => 'Pre-inscription deleted successfully'
+                'message' => 'Preinscription deleted successfully'
             ]);
         } catch (Exception $e) {
             return response()->json([

--- a/app/Http/Controllers/PreInscriptionController.php
+++ b/app/Http/Controllers/PreInscriptionController.php
@@ -34,6 +34,10 @@ class PreInscriptionController extends Controller
             $own = $user->can('ver preinscripciones propias');
             $staff = $user->can('ver preinscripciones del personal');
 
+            if (!$all && !$own && !$staff) {
+                return back()->with('forbidden', 'No tienes permiso para realizar esta acción. Si crees que esto es un error, contacta al administrador del sistema.');
+            }
+
             $query = PreInscription::query()->with(['country', 'stake'])->orderBy('created_at', 'desc');
 
             if ($request->has('search')) {

--- a/app/Http/Controllers/ReferenceController.php
+++ b/app/Http/Controllers/ReferenceController.php
@@ -30,6 +30,10 @@ class ReferenceController extends Controller
             $own = $user->can('ver preinscripciones propias');
             $staff = $user->can('ver preinscripciones del personal');
 
+            if (!$all && !$own && !$staff) {
+                return back()->with('forbidden', 'No tienes permiso para realizar esta acción. Si crees que esto es un error, contacta al administrador del sistema.');
+            }
+
             $query = Reference::query()->with(['country', 'stake', 'modifier'])->orderBy('created_at', 'desc');
 
             if ($request->has('search')) {

--- a/app/Http/Controllers/ReferenceController.php
+++ b/app/Http/Controllers/ReferenceController.php
@@ -26,9 +26,9 @@ class ReferenceController extends Controller
     {
         try {
             $user = Auth::user();
-            $all = $user->can('ver todas las preinscripciones');
-            $own = $user->can('ver preinscripciones propias');
-            $staff = $user->can('ver preinscripciones del personal');
+            $all = $user->can('ver todas las referencias');
+            $own = $user->can('ver referencias propias');
+            $staff = $user->can('ver referencias del personal');
 
             if (!$all && !$own && !$staff) {
                 return back()->with('forbidden', 'No tienes permiso para realizar esta acción. Si crees que esto es un error, contacta al administrador del sistema.');
@@ -319,9 +319,9 @@ class ReferenceController extends Controller
     {
         try {
             $user = Auth::user();
-            $all = $user->can('ver todas las preinscripciones');
-            $own = $user->can('ver preinscripciones propias');
-            $staff = $user->can('ver preinscripciones del personal');
+            $all = $user->can('ver todas las referencias');
+            $own = $user->can('ver referencias propias');
+            $staff = $user->can('ver referencias del personal');
 
             if (!$all && !$own && !$staff) {
                 return back()->with('forbidden', 'No tienes permiso para realizar esta acción. Si crees que esto es un error, contacta al administrador del sistema.');

--- a/app/Http/Controllers/ReferenceController.php
+++ b/app/Http/Controllers/ReferenceController.php
@@ -319,9 +319,17 @@ class ReferenceController extends Controller
     {
         try {
             $user = Auth::user();
+            $all = $user->can('ver todas las preinscripciones');
+            $own = $user->can('ver preinscripciones propias');
+            $staff = $user->can('ver preinscripciones del personal');
+
+            if (!$all && !$own && !$staff) {
+                return back()->with('forbidden', 'No tienes permiso para realizar esta acción. Si crees que esto es un error, contacta al administrador del sistema.');
+            }
+
             $query = Reference::query()->with(['country', 'stake', 'modifier']);
 
-            if ($user->hasRole('Responsable') && !$user->hasRole('Administrador')) {
+            if (!$all && !$staff && $own) {
                 $stakesIds = Stake::where('user_id', $user->id)->pluck('id');
                 $query->whereIn('stake_id', $stakesIds);
             }

--- a/app/Http/Controllers/ReferenceController.php
+++ b/app/Http/Controllers/ReferenceController.php
@@ -80,7 +80,7 @@ class ReferenceController extends Controller
             $references = $query->paginate($perPage, ['*'], 'page', $page);
 
             $responsables = !$all ? null :
-                User::role('Responsable')
+                User::permission('recibir asignaciones de estacas')
                 ->get()
                 ->map(fn($u) => [
                     'id' => $u->id,

--- a/app/Http/Controllers/StakeController.php
+++ b/app/Http/Controllers/StakeController.php
@@ -30,12 +30,14 @@ class StakeController extends Controller
         $page = $request->input('page', 1);
         $stakes = $query->orderBy('created_at', 'desc')->paginate($perPage, ['*'], 'page', $page);
 
-        $users = User::all()->map(function ($user) {
-            return [
-                'id' => $user->id,
-                'name' => $user->full_name,
-            ];
-        });
+        $users = User::permission('recibir asignaciones de estacas')
+            ->get()
+            ->map(function ($user) {
+                return [
+                    'id' => $user->id,
+                    'name' => $user->full_name,
+                ];
+            });
 
         return Inertia::render('Stakes/Index', [
             'stakes' => $stakes,

--- a/database/seeders/data/permissions.json
+++ b/database/seeders/data/permissions.json
@@ -78,12 +78,6 @@
         "key": "course:delete"
     },
     {
-        "name": "dashboard de referencias",
-        "description": "Permite ver el dashboard de referencias",
-        "category": "Gestion de referencias",
-        "key": "reference:dashboard"
-    },
-    {
         "name": "ver todas las referencias",
         "description": "Permite ver la lista de referencias",
         "category": "Gestion de referencias",
@@ -112,12 +106,6 @@
         "description": "Permite actualizar los datos de una referencia sin cambiar su estado",
         "category": "Gestion de referencias",
         "key": "reference:update"
-    },
-    {
-        "name": "dashboard de preinscripciones",
-        "description": "Permite ver el dashboard de preinscripciones",
-        "category": "Gestión de preinscripciones",
-        "key": "preinscripciones:dashboard"
     },
     {
         "name": "ver todas las preinscripciones",

--- a/database/seeders/data/permissions.json
+++ b/database/seeders/data/permissions.json
@@ -24,6 +24,12 @@
         "key": "user:delete"
     },
     {
+        "name": "recibir asignaciones de estacas",
+        "description": "Permite que un usuario reciba asignaciones de estacas",
+        "category": "Gestión de Usuarios",
+        "key": "user:receive-assignments"
+    },
+    {
         "name": "ver roles",
         "description": "Permite ver la lista de roles",
         "category": "Gestión de Roles",

--- a/resources/js/components/pre-registration/pre-inscriptions-data-table.tsx
+++ b/resources/js/components/pre-registration/pre-inscriptions-data-table.tsx
@@ -6,7 +6,6 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { validateRole } from '@/lib/utils';
 import { SharedData } from '@/types';
 import { type PreInscription } from '@/types/pre-inscription';
 import { router, usePage } from '@inertiajs/react';
@@ -134,8 +133,8 @@ export const createColumns = ({
             cell: ({ row }) => {
                 const preInscription = row.original;
                 const { auth } = usePage<SharedData>().props;
-                const isPending = preInscription.status.id === 1 || validateRole(auth.user.roles, 'Administrador');
-                const canEdit = validateRole(auth.user.roles, 'Administrador') || validateRole(auth.user.roles, 'Responsable');
+                const canEdit = auth.user.user_permissions.includes('pre-inscription:update');
+                const isPending = preInscription.status.id === 1 || canEdit;
 
                 const handleEditPreInscription = () => {
                     router.visit(route('pre-inscription.edit', preInscription.id));

--- a/resources/js/components/pre-registration/references-data-table.tsx
+++ b/resources/js/components/pre-registration/references-data-table.tsx
@@ -6,7 +6,6 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { validateRole } from '@/lib/utils';
 import { SharedData } from '@/types';
 import { Reference } from '@/types/reference';
 import { router, usePage } from '@inertiajs/react';

--- a/resources/js/components/pre-registration/references-data-table.tsx
+++ b/resources/js/components/pre-registration/references-data-table.tsx
@@ -113,8 +113,9 @@ export const createColumns = ({ onEditReference }: { onEditReference: (reference
         cell: ({ row }) => {
             const reference = row.original;
             const { auth } = usePage<SharedData>().props;
-            const isPending = reference.status.id === 1 || validateRole(auth.user.roles, 'Administrador');
-            const canEdit = validateRole(auth.user.roles, 'Administrador') || validateRole(auth.user.roles, 'Responsable');
+
+            const canEdit = auth.user.user_permissions.includes('reference:update');
+            const isPending = reference.status.id === 1 || canEdit;
 
             const handleEditReference = () => {
                 router.visit(route('references.edit', reference.id));

--- a/resources/js/components/users/user-data-table-config.tsx
+++ b/resources/js/components/users/user-data-table-config.tsx
@@ -118,7 +118,8 @@ export const createColumns = ({ onDeleteUser }: UserDataTableProps): ColumnDef<U
         id: "actions",
         enableHiding: false,
         cell: ({ row }) => {
-            const user = row.original
+            const user = row.original;
+
             return (
                 <DropdownMenu>
                     <DropdownMenuTrigger asChild>
@@ -140,7 +141,7 @@ export const createColumns = ({ onDeleteUser }: UserDataTableProps): ColumnDef<U
                                 Editar
                             </TextLink>
                         </DropdownMenuItem>
-                        {user.roles.some(role => role.name === "Responsable") && (
+                        {user.user_permissions.includes('user:receive-assignments') && (
                             <DropdownMenuItem>
                                 <TextLink
                                     href={route('users.assign-stakes', user.id)}

--- a/resources/js/lib/utils.ts
+++ b/resources/js/lib/utils.ts
@@ -8,10 +8,6 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 
-export function validateRole(roles: Roles[], allowedRole: String): boolean {
-    return roles.some((r) => r.name === allowedRole)
-}
-
 export const filterReferenceStatus = (enums: Enums, status: number) => {
     switch (status) {
         case 1:

--- a/resources/js/lib/utils.ts
+++ b/resources/js/lib/utils.ts
@@ -1,5 +1,4 @@
 import { Enums } from '@/types/global';
-import { Roles } from '@/types/roles';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -117,8 +117,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
                 ->name('dashboard')
                 ->middleware('can:dashboard de referencias');
             Route::get('/', 'index')
-                ->name('index')
-                ->middleware('can:ver todas las referencias,ver referencias propias,ver referencias del personal');
+                ->name('index');
             Route::get('{id}/edit', 'edit')
                 ->name('edit')
                 ->middleware('can:actualizar referencias');
@@ -136,8 +135,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
                 ->name('dashboard')
                 ->middleware('can:dashboard de preinscripciones');
             Route::get('/', 'index')
-                ->name('index')
-                ->middleware('can:ver todas las preinscripciones,ver preinscripciones propias,ver preinscripciones del personal');
+                ->name('index');
             Route::get('{id}/edit', 'edit')
                 ->name('edit')
                 ->middleware('can:actualizar preinscripciones');

--- a/routes/web.php
+++ b/routes/web.php
@@ -114,8 +114,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::prefix('references')->name('references.')
         ->controller(ReferenceController::class)->group(function () {
             Route::get('/dashboard', 'dashboard')
-                ->name('dashboard')
-                ->middleware('can:dashboard de referencias');
+                ->name('dashboard');
             Route::get('/', 'index')
                 ->name('index');
             Route::get('{id}/edit', 'edit')
@@ -132,8 +131,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::prefix('pre-inscription')->name('pre-inscription.')
         ->controller(PreInscriptionController::class)->group(function () {
             Route::get('/dashboard', 'dashboard')
-                ->name('dashboard')
-                ->middleware('can:dashboard de preinscripciones');
+                ->name('dashboard');
             Route::get('/', 'index')
                 ->name('index');
             Route::get('{id}/edit', 'edit')


### PR DESCRIPTION
This pull request introduces several important improvements to permission management and access control across the application, particularly for pre-inscriptions, references, and stake assignments. The changes focus on replacing role-based checks with permission-based checks, improving security and flexibility, and cleaning up unused code and permissions.

**Access Control and Permission Improvements:**

* Replaced role-based access checks (e.g., `hasRole('Responsable')`) with permission-based checks (e.g., `can('ver todas las preinscripciones')`, `can('ver preinscripciones propias')`, `can('ver preinscripciones del personal')`) in controllers for pre-inscriptions and references, ensuring more granular and flexible access control. Unauthorized users are now redirected with a clear error message. [[1]](diffhunk://#diff-cc8cf07424ba2e1ae3256739dc1683155616cd19ca0ca990ffc74b3bfaa90254R37-R40) [[2]](diffhunk://#diff-d669d1e952a4f19eb9fd7b69ae5bfbd3f4b07289c07a8802d936f9833495ab4eR33-R36) [[3]](diffhunk://#diff-cc8cf07424ba2e1ae3256739dc1683155616cd19ca0ca990ffc74b3bfaa90254L389-L399) [[4]](diffhunk://#diff-d669d1e952a4f19eb9fd7b69ae5bfbd3f4b07289c07a8802d936f9833495ab4eR322-R332)
* Updated the logic for fetching "responsables" and users eligible for stake assignments to use the new `recibir asignaciones de estacas` permission instead of roles, both in backend controllers and frontend data tables. [[1]](diffhunk://#diff-cc8cf07424ba2e1ae3256739dc1683155616cd19ca0ca990ffc74b3bfaa90254L86-R90) [[2]](diffhunk://#diff-d669d1e952a4f19eb9fd7b69ae5bfbd3f4b07289c07a8802d936f9833495ab4eL79-R83) [[3]](diffhunk://#diff-2cd552bd14f53539cd046456a97e76145a5484e9a0863eeed0da1edddd1a1e2aL33-R35) [[4]](diffhunk://#diff-7ed7566f832d496661ca268a6d5f2e34106f050b48e8dc9e3d56d94b0dd2b428L143-R144) [[5]](diffhunk://#diff-d7fdcbde67d7530ba52c2a5ebf61c964e31cdb6eba7c11541f39cdb6b9aae12cR26-R31)

**Frontend Permission Handling:**

* Refactored frontend logic to check user permissions (e.g., `user_permissions.includes('pre-inscription:update')` and `user_permissions.includes('reference:update')`) instead of roles, aligning with backend permission changes and removing the now-unused `validateRole` utility function. [[1]](diffhunk://#diff-b2ae62195741e1183786832302bc94827b27f1eeadc49f756073838905cc2f2fL137-R137) [[2]](diffhunk://#diff-101bd056294ee58477ded952aee3f67f6173551e69dc11d0c857e3cfd034c080L116-R117) [[3]](diffhunk://#diff-ceba38648f9f211c6eb09e7d5787089e5b90cffe82efd25f0fd1205024bd48c4L11-L14)

**Permissions Data and Routing Cleanup:**

* Added the new `recibir asignaciones de estacas` permission to `permissions.json` and removed obsolete dashboard permissions (`dashboard de referencias` and `dashboard de preinscripciones`). [[1]](diffhunk://#diff-d7fdcbde67d7530ba52c2a5ebf61c964e31cdb6eba7c11541f39cdb6b9aae12cR26-R31) [[2]](diffhunk://#diff-d7fdcbde67d7530ba52c2a5ebf61c964e31cdb6eba7c11541f39cdb6b9aae12cL80-L85) [[3]](diffhunk://#diff-d7fdcbde67d7530ba52c2a5ebf61c964e31cdb6eba7c11541f39cdb6b9aae12cL116-L121)
* Simplified route middleware in `web.php` by removing explicit `can` middleware for dashboards and index routes, delegating access control to controller logic. [[1]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL117-R119) [[2]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL136-R136)

**Minor Fixes and Consistency:**

* Fixed case sensitivity in the import of the `Course` model in `CourseController.php`.
* Standardized success and error messages for pre-inscriptions and references. [[1]](diffhunk://#diff-cc8cf07424ba2e1ae3256739dc1683155616cd19ca0ca990ffc74b3bfaa90254L303-R307) [[2]](diffhunk://#diff-cc8cf07424ba2e1ae3256739dc1683155616cd19ca0ca990ffc74b3bfaa90254L371-R375)
* Minor frontend code cleanups and whitespace adjustments. [[1]](diffhunk://#diff-7ed7566f832d496661ca268a6d5f2e34106f050b48e8dc9e3d56d94b0dd2b428L121-R122) [[2]](diffhunk://#diff-b2ae62195741e1183786832302bc94827b27f1eeadc49f756073838905cc2f2fL9) [[3]](diffhunk://#diff-101bd056294ee58477ded952aee3f67f6173551e69dc11d0c857e3cfd034c080L9) [[4]](diffhunk://#diff-ceba38648f9f211c6eb09e7d5787089e5b90cffe82efd25f0fd1205024bd48c4L2)

These changes collectively enhance security, maintainability, and clarity in how permissions are managed throughout the application.