### PR TITLE
Refactor: simplify stake filtering logic in PreInscription and Refere…

### DIFF
--- a/app/Http/Controllers/PreInscriptionController.php
+++ b/app/Http/Controllers/PreInscriptionController.php
@@ -51,7 +51,7 @@ class PreInscriptionController extends Controller
                 });
             }
 
-            if ($own && !$all && !$staff) {
+            if ($own && !$all) {
                 $stakesIds = Stake::where('user_id', $user->id)->pluck('id');
                 $query->whereIn('stake_id', $stakesIds);
             }
@@ -402,6 +402,11 @@ class PreInscriptionController extends Controller
             }
 
             $query = PreInscription::query()->with(['country', 'stake']);
+
+            if ($own && !$all) {
+                $stakesIds = Stake::where('user_id', $user->id)->pluck('id');
+                $query->whereIn('stake_id', $stakesIds);
+            }
 
             $preInscriptions = $query->get();
             $total = $preInscriptions->count();

--- a/app/Http/Controllers/ReferenceController.php
+++ b/app/Http/Controllers/ReferenceController.php
@@ -43,7 +43,7 @@ class ReferenceController extends Controller
                 });
             }
 
-            if (!$all && !$staff && $own) {
+            if (!$all && $own) {
                 $stakesIds = Stake::where('user_id', $user->id)->pluck('id');
                 $query->whereIn('stake_id', $stakesIds);
             }
@@ -329,7 +329,7 @@ class ReferenceController extends Controller
 
             $query = Reference::query()->with(['country', 'stake', 'modifier']);
 
-            if (!$all && !$staff && $own) {
+            if (!$all && $own) {
                 $stakesIds = Stake::where('user_id', $user->id)->pluck('id');
                 $query->whereIn('stake_id', $stakesIds);
             }


### PR DESCRIPTION
This pull request simplifies the logic for filtering records by user-owned stakes in both the `PreInscriptionController` and `ReferenceController`. The main change is the removal of the `!$staff` condition from several permission checks, ensuring that records are filtered by the user's stakes whenever the `own` flag is set and `all` is not set.

Permission logic simplification:

* In `PreInscriptionController`, both the `index` and `dashboard` methods now filter by the user's stakes whenever `$own` is true and `$all` is false, removing the previous requirement that `$staff` must also be false. [[1]](diffhunk://#diff-cc8cf07424ba2e1ae3256739dc1683155616cd19ca0ca990ffc74b3bfaa90254L54-R54) [[2]](diffhunk://#diff-cc8cf07424ba2e1ae3256739dc1683155616cd19ca0ca990ffc74b3bfaa90254R406-R410)
* In `ReferenceController`, both the `index` and `dashboard` methods similarly update their logic to filter by the user's stakes based only on `$own` and `$all`, no longer checking the `$staff` flag. [[1]](diffhunk://#diff-d669d1e952a4f19eb9fd7b69ae5bfbd3f4b07289c07a8802d936f9833495ab4eL46-R46) [[2]](diffhunk://#diff-d669d1e952a4f19eb9fd7b69ae5bfbd3f4b07289c07a8802d936f9833495ab4eL332-R332)…nce controllers