### PR TITLE
Feature/phone number style required field

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -165,4 +165,7 @@
     label:has(+:is(*:required, *[aria-required="true"])) {
         @apply after:content-['*'] after:text-red-500 after:ml-1 after:text-base;
     }
+    label:has(+ div input:required) {
+        @apply after:content-['*'] after:text-red-500 after:ml-1 after:text-base;
+    }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -168,4 +168,7 @@
     label:has(+ div input:required) {
         @apply after:content-['*'] after:text-red-500 after:ml-1 after:text-base;
     }
+    label:has(+ div[data-required="true"]) {
+        @apply after:content-['*'] after:text-red-500 after:ml-1 after:text-base;
+    }
 }

--- a/resources/js/components/pre-registration/steps/PreRegistrationFormStep.tsx
+++ b/resources/js/components/pre-registration/steps/PreRegistrationFormStep.tsx
@@ -222,7 +222,7 @@ export function PreRegistrationFormStep({ countries, request }: PreRegistrationF
                                         selectedCountryId={data.country_id}
                                         minLength={3}
                                         maxLength={18}
-                                        required
+                                        
                                     />
                                 </div>
                                 {errors.additional_phone && <p className="text-sm text-red-500">{errors.additional_phone}</p>}
@@ -238,6 +238,7 @@ export function PreRegistrationFormStep({ countries, request }: PreRegistrationF
                                     label={forms.pre_inscription.fields.stake}
                                     disabled={!data.country_id}
                                     placeholder={data.country_id ? 'Selecciona una estaca/distrito/misión' : 'Primero selecciona un país'}
+                                    required
                                 />
 
                                 {errors.stake_id && <p className="text-sm text-red-500">{errors.stake_id}</p>}

--- a/resources/js/components/pre-registration/steps/PreRegistrationFormStep.tsx
+++ b/resources/js/components/pre-registration/steps/PreRegistrationFormStep.tsx
@@ -222,6 +222,7 @@ export function PreRegistrationFormStep({ countries, request }: PreRegistrationF
                                         selectedCountryId={data.country_id}
                                         minLength={3}
                                         maxLength={18}
+                                        required
                                     />
                                 </div>
                                 {errors.additional_phone && <p className="text-sm text-red-500">{errors.additional_phone}</p>}

--- a/resources/js/components/pre-registration/steps/ReferralFormStep.tsx
+++ b/resources/js/components/pre-registration/steps/ReferralFormStep.tsx
@@ -185,6 +185,7 @@ export function ReferralFormStep({ countries, request, }: ReferralFormStepProps)
                 label={forms.referral.fields.stake}
                 disabled={!data.country_id}
                 placeholder={data.country_id ? "Selecciona una estaca/distrito/misión" : "Primero selecciona un país"}
+                required
               />
               {errors.stake_id && <p className="text-red-500 text-sm">{errors.stake_id}</p>}
             </div>

--- a/resources/js/components/ui/searchable-select.tsx
+++ b/resources/js/components/ui/searchable-select.tsx
@@ -56,7 +56,7 @@ const SearchableSelect = React.forwardRef<HTMLDivElement, SearchableSelectProps>
     return (
         <div className="relative space-y-2" ref={ref} {...props}>
             {label && (
-                <Label htmlFor={id}>{label}</Label>
+                <Label htmlFor={id} className={cn(required && 'after:content-["*"] after:text-red-500 after:ml-1 after:text-base')}>{label}</Label>
             )}
 
             <div>


### PR DESCRIPTION
This pull request introduces a minor UI improvement for form validation. It ensures that required indicators (asterisks) are correctly displayed for input fields, including those inside nested `div` elements, and marks the `additional_phone` input as required.

Form validation and UI consistency:

* Updated the CSS in `app.css` to display the required field asterisk for labels whose required input is inside a nested `div`, ensuring visual consistency for nested form layouts.
* Marked the `additional_phone` input as required in `PreRegistrationFormStep.tsx`, enforcing validation and aligning with the UI indicator.