### PR TITLE
Feature/dummy stake

### DIFF
--- a/app/Http/Controllers/ReferenceController.php
+++ b/app/Http/Controllers/ReferenceController.php
@@ -132,6 +132,13 @@ class ReferenceController extends Controller
     public function store(Request $request)
     {
         try {
+            if (!$request->input('stake_id')) {
+                $stakes = Stake::where('status', StatusEnum::ACTIVE->value)
+                    ->where('country_id', $request->input('country_id'))->get();
+                $randomStake = $stakes->random();
+                $request->merge(['stake_id' => $randomStake->id]);
+            }
+
             $validated = $request->validate([
                 'name' => 'required|string|max:255',
                 'gender' => 'integer',
@@ -153,7 +160,7 @@ class ReferenceController extends Controller
 
             $stake = Stake::find($validated['stake_id']);
             $user = $stake->user;
-            $user->notify(new RequestNotification($this->buildReferenceNotification($user, $reference)));
+            /* $user->notify(new RequestNotification($this->buildReferenceNotification($user, $reference))); */
 
             return  back()->with('success', $message);
         } catch (\Illuminate\Validation\ValidationException $e) {

--- a/lang/en/forms.php
+++ b/lang/en/forms.php
@@ -94,6 +94,7 @@ return [
             'referrer_name' => 'Your Name',
             'referrer_phone' => 'Your Phone',
             'relationship' => 'Relationship with Referred Person',
+            'unknown_stake' => 'I do not know their stake/district/mission',
         ],
         'overview' => [
             'title' => 'Review reference data',

--- a/lang/es/forms.php
+++ b/lang/es/forms.php
@@ -94,6 +94,7 @@ return [
             'referrer_name' => 'Tu nombre',
             'referrer_phone' => 'Tu teléfono',
             'relationship' => 'Relación con la persona referida',
+            'unknown_stake' => 'No conozco su estaca/distrito/misión',
         ],
         'overview' => [
             'title' => 'Revisar datos de referencia',

--- a/lang/ht/forms.php
+++ b/lang/ht/forms.php
@@ -95,6 +95,7 @@ return [
             'referrer_name' => 'Non Ou',
             'referrer_phone' => 'Telefòn Ou',
             'relationship' => 'Relasyon ak Moun nan',
+            'unknown_stake' => 'M pa konnen poto/distri/misyon li',
         ],
         'overview' => [
             'title' => 'Revize done referans yo',

--- a/lang/pt/forms.php
+++ b/lang/pt/forms.php
@@ -94,6 +94,7 @@ return [
             'referrer_name' => 'Seu Nome',
             'referrer_phone' => 'Seu Telefone',
             'relationship' => 'Relacionamento com a Pessoa Indicada',
+            'unknown_stake' => 'Não sei a estaca/distrito/missão dele(a)'
         ],
         'overview' => [
             'title' => 'Revisar dados da referência',

--- a/resources/js/components/pre-registration/steps/ReferralFormStep.tsx
+++ b/resources/js/components/pre-registration/steps/ReferralFormStep.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from '@/components/ui/input';
 import { Label } from "@/components/ui/label"
+import { Checkbox } from "@/components/ui/checkbox"
 
 import {
   Select,
@@ -42,6 +43,7 @@ export function ReferralFormStep({ countries, request, }: ReferralFormStepProps)
   const { stakes } = useFilteredStakes(data.country_id);
 
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [dontKnowStake, setDontKnowStake] = useState(false);
 
   const isFull = new URLSearchParams(window.location.search).get('full') === 'true';
 
@@ -77,6 +79,15 @@ export function ReferralFormStep({ countries, request, }: ReferralFormStepProps)
     },
     [setData],
   );
+
+  const handleDontKnowStakeChange = (checked: boolean) => {
+    setDontKnowStake(checked);
+    if (checked) {
+      setData('stake_id', 0);
+    } else {
+      setData('stake_id', '');
+    }
+  };
 
   return (
     <Card className="w-full max-w-4xl shadow-2xl border-0 overflow-hidden pt-0 mx-auto">
@@ -176,17 +187,35 @@ export function ReferralFormStep({ countries, request, }: ReferralFormStepProps)
             </div>
 
             <div>
-              <SearchableSelect
-                data={stakes}
-                name="stake_id"
-                id="stake_id"
-                value={data.stake_id.toString()}
-                onValueChange={(value) => setData('stake_id', Number(value))}
-                label={forms.referral.fields.stake}
-                disabled={!data.country_id}
-                placeholder={data.country_id ? "Selecciona una estaca/distrito/misión" : "Primero selecciona un país"}
-                required
-              />
+              <Label htmlFor="stake_id">{forms.referral.fields.stake}</Label>
+              <div className="space-y-3">
+                <SearchableSelect
+                  data={stakes}
+                  name="stake_id"
+                  id="stake_id"
+                  value={dontKnowStake ? "" : data.stake_id.toString()}
+                  onValueChange={(value) => setData('stake_id', Number(value))}
+                  label=""
+                  disabled={!data.country_id || dontKnowStake}
+                  placeholder={data.country_id ? "Selecciona una estaca/distrito/misión" : "Primero selecciona un país"}
+                  required={!dontKnowStake}
+                />
+
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="dont_know_stake"
+                    checked={dontKnowStake}
+                    onCheckedChange={handleDontKnowStakeChange}
+                    disabled={!data.country_id}
+                  />
+                  <Label
+                    htmlFor="dont_know_stake"
+                    className="text-sm text-gray-600 cursor-pointer"
+                  >
+                    {forms.referral.fields.unknown_stake}
+                  </Label>
+                </div>
+              </div>
               {errors.stake_id && <p className="text-red-500 text-sm">{errors.stake_id}</p>}
             </div>
 

--- a/resources/js/lib/schemas/referral.ts
+++ b/resources/js/lib/schemas/referral.ts
@@ -9,7 +9,7 @@ export const referralFormSchema = z.object({
     phone: z.string().min(10, "El teléfono debe tener al menos 10 dígitos").refine((val) => validatePhoneLength(val), {
         message: "El teléfono debe tener entre 7 y 10 dígitos.",
     }),
-    stake_id: z.coerce.number().min(1, "La estaca/distrito/misión es obligatoria"),
+    stake_id: z.coerce.number().min(0, "La estaca/distrito/misión es obligatoria"),
     referrer_name: z.string().min(1, "Tu nombre es obligatorio"),
     referrer_phone: z.string().min(1, "Tu teléfono es obligatorio").refine((val) => validatePhoneLength(val), {
         message: "El teléfono debe tener entre 7 y 10 dígitos.",

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -165,6 +165,7 @@ type Translation = {
                 referrer_name: string;
                 referrer_phone: string;
                 relationship: string;
+                unknown_stake: string;
             },
             overview: {
                 title: string;


### PR DESCRIPTION
This pull request introduces a new "I do not know their stake/district/mission" option to the referral form, allowing users to submit a referral even if they do not know the stake information. The backend and frontend have been updated to support this feature, including form validation, UI changes, and localization updates.

**Referral Form Enhancements**
* Added a checkbox option to the referral form UI that allows users to indicate they do not know the stake/district/mission, which disables the stake selection and updates the form data accordingly (`ReferralFormStep.tsx`). [[1]](diffhunk://#diff-13a43cf35f91d4ddf04f704181be6cb84dc1959e1c3234b5970e20f483fb88caR46) [[2]](diffhunk://#diff-13a43cf35f91d4ddf04f704181be6cb84dc1959e1c3234b5970e20f483fb88caR83-R91) [[3]](diffhunk://#diff-13a43cf35f91d4ddf04f704181be6cb84dc1959e1c3234b5970e20f483fb88caR190-R218)
* Updated form validation schema to allow `stake_id` to be zero when the user selects "unknown stake" (`referral.ts`).

**Backend Logic Updates**
* Modified the backend controller to randomly assign an active stake from the selected country if the user does not provide a stake ID (`ReferenceController.php`).
* Temporarily commented out the notification logic for stake users when a reference is created (`ReferenceController.php`).

**Localization**
* Added translations for the "I do not know their stake/district/mission" option in English, Spanish, Haitian Creole, and Portuguese (`forms.php` in `lang/en`, `lang/es`, `lang/ht`, `lang/pt`). [[1]](diffhunk://#diff-078558518237405698242c4d3afe67f90a617e9034f26f433302fb5ff8c71e72R97) [[2]](diffhunk://#diff-3464698f600f8e32d0bde3f8802d0533ecfe7d9f7eca2c0d5bbeaafb5030426aR97) [[3]](diffhunk://#diff-6dc0d8c6568e9642504f0d0c106796ceafcb016f5243f36495cd4b54a46084d4R98) [[4]](diffhunk://#diff-f857e5e78f60b371b61928a6457b9aa0482ab20eca07ea064fcb8cd7e93ba162R97)