### PR TITLE
Feature/update phone validation to allow 7 to 11 digits in pre-regist…

### DIFF
--- a/resources/js/lib/schemas/custom-phone-validation.ts
+++ b/resources/js/lib/schemas/custom-phone-validation.ts
@@ -1,21 +1,18 @@
-
-
 /**
  * Validates a phone number string by checking if the length of the numeric part (after the closing parenthesis)
  * is within the specified minimum and maximum bounds.
  *
  * @param phone - The phone number string to validate. Expected format: "<prefix>)<number>".
  * @param min - The minimum allowed length for the numeric part. Defaults to 7.
- * @param max - The maximum allowed length for the numeric part. Defaults to 10.
+ * @param max - The maximum allowed length for the numeric part. Defaults to 11.
  * @returns `true` if the numeric part's length is between `min` and `max` (inclusive), otherwise `false`.
  */
-export const customPhoneValidation = (phone: string, min = 7, max = 10): boolean => {
-
+export const customPhoneValidation = (phone: string, min = 7, max = 11): boolean => {
     if (!phone || typeof phone !== 'string') {
         return false;
     }
 
-    const parts = phone.split(")");
+    const parts = phone.split(')');
     if (parts.length !== 2) {
         return false;
     }
@@ -27,6 +24,6 @@ export const customPhoneValidation = (phone: string, min = 7, max = 10): boolean
     }
 
     return cleanPhone.length >= min && cleanPhone.length <= max;
-}
+};
 
 export default customPhoneValidation;

--- a/resources/js/lib/schemas/pre-registration.ts
+++ b/resources/js/lib/schemas/pre-registration.ts
@@ -1,5 +1,5 @@
-import { z } from "zod";
-import validatePhoneLength from "@/lib/schemas/custom-phone-validation";
+import validatePhoneLength from '@/lib/schemas/custom-phone-validation';
+import { z } from 'zod';
 // Función auxiliar para validar campos obligatorios que pueden ser null/undefined
 function requiredField(ctx: z.RefinementCtx, value: unknown, path: string[], message: string) {
     if (value === null || value === undefined) {
@@ -12,42 +12,49 @@ function requiredField(ctx: z.RefinementCtx, value: unknown, path: string[], mes
 }
 
 export const preRegistrationSchema = z.object({
-    first_name: z.string().min(1, "El primer nombre es obligatorio."),
-    last_name: z.string().min(1, "El primer apellido es obligatorio."),
-    gender: z.number().min(1, "El género es obligatorio."),
-    age: z.coerce.number().min(18, "Edad mínima 18").max(100, "Edad máxima 100."),
-    country_id: z.number().min(1, "El país es obligatorio."),
-    phone: z.string().min(1, "El teléfono es obligatorio.").refine((val) => validatePhoneLength(val), {
-        message: "El teléfono debe tener entre 7 y 10 dígitos.",
-    }),
-    additional_phone: z.string().optional().refine((val) => !val || validatePhoneLength(val), {
-        message: "El teléfono adicional debe tener entre 7 y 10 dígitos.",
-    }),
-    stake_id: z.number().min(1, "La estaca es obligatoria."),
-    email: z.string().email("Correo inválido."),
-    marital_status: z.number().min(1, "El estado civil es obligatorio."),
-    served_mission: z.number().min(1, "Este campo es obligatorio."),
+    first_name: z.string().min(1, 'El primer nombre es obligatorio.'),
+    last_name: z.string().min(1, 'El primer apellido es obligatorio.'),
+    gender: z.number().min(1, 'El género es obligatorio.'),
+    age: z.coerce.number().min(18, 'Edad mínima 18').max(100, 'Edad máxima 100.'),
+    country_id: z.number().min(1, 'El país es obligatorio.'),
+    phone: z
+        .string()
+        .min(1, 'El teléfono es obligatorio.')
+        .refine((val) => validatePhoneLength(val), {
+            message: 'El teléfono debe tener entre 7 y 11 dígitos.',
+        }),
+    additional_phone: z
+        .string()
+        .optional()
+        .refine((val) => !val || validatePhoneLength(val), {
+            message: 'El teléfono adicional debe tener entre 7 y 11 dígitos.',
+        }),
+    stake_id: z.number().min(1, 'La estaca es obligatoria.'),
+    email: z.string().email('Correo inválido.'),
+    marital_status: z.number().min(1, 'El estado civil es obligatorio.'),
+    served_mission: z.number().min(1, 'Este campo es obligatorio.'),
 });
 
-export const femaleValidationSchema = z.object({
-    currently_working: z.boolean().nullable(),
-    job_type_preference: z.number().nullable(),
-    available_full_time: z.boolean().nullable(),
-}).superRefine((data, ctx) => {
-    requiredField(ctx, data.currently_working, ["currently_working"], "Este campo es obligatorio");
-    if (data.currently_working === false && !data.job_type_preference) {
-        ctx.addIssue({
-            path: ["job_type_preference"],
-            code: z.ZodIssueCode.custom,
-            message: "Este campo es obligatorio",
-        });
-    }
-    if (data.job_type_preference === 2 && (data.available_full_time === null || data.available_full_time === undefined)) {
-        ctx.addIssue({
-            path: ["available_full_time"],
-            code: z.ZodIssueCode.custom,
-            message: "Este campo es obligatorio",
-        });
-    }
-});
-
+export const femaleValidationSchema = z
+    .object({
+        currently_working: z.boolean().nullable(),
+        job_type_preference: z.number().nullable(),
+        available_full_time: z.boolean().nullable(),
+    })
+    .superRefine((data, ctx) => {
+        requiredField(ctx, data.currently_working, ['currently_working'], 'Este campo es obligatorio');
+        if (data.currently_working === false && !data.job_type_preference) {
+            ctx.addIssue({
+                path: ['job_type_preference'],
+                code: z.ZodIssueCode.custom,
+                message: 'Este campo es obligatorio',
+            });
+        }
+        if (data.job_type_preference === 2 && (data.available_full_time === null || data.available_full_time === undefined)) {
+            ctx.addIssue({
+                path: ['available_full_time'],
+                code: z.ZodIssueCode.custom,
+                message: 'Este campo es obligatorio',
+            });
+        }
+    });

--- a/resources/js/lib/schemas/referral.ts
+++ b/resources/js/lib/schemas/referral.ts
@@ -1,18 +1,24 @@
-import { z } from "zod";
-import validatePhoneLength from "@/lib/schemas/custom-phone-validation";
+import validatePhoneLength from '@/lib/schemas/custom-phone-validation';
+import { z } from 'zod';
 
 export const referralFormSchema = z.object({
-    name: z.string().min(1, "El nombre del referido es obligatorio."),
-    gender: z.coerce.number().min(1, "El género es obligatorio"),
-    country_id: z.coerce.number().min(1, "El país es obligatorio"),
-    age: z.coerce.number().min(18, "La edad mínima es 18 años"),
-    phone: z.string().min(10, "El teléfono debe tener al menos 10 dígitos").refine((val) => validatePhoneLength(val), {
-        message: "El teléfono debe tener entre 7 y 10 dígitos.",
-    }),
-    stake_id: z.coerce.number().min(1, "La estaca/distrito/misión es obligatoria"),
-    referrer_name: z.string().min(1, "Tu nombre es obligatorio"),
-    referrer_phone: z.string().min(1, "Tu teléfono es obligatorio").refine((val) => validatePhoneLength(val), {
-        message: "El teléfono debe tener entre 7 y 10 dígitos.",
-    }),
-    relationship_with_referred: z.coerce.number().min(1, "La relación con la persona referida es obligatoria"),
+    name: z.string().min(1, 'El nombre del referido es obligatorio.'),
+    gender: z.coerce.number().min(1, 'El género es obligatorio'),
+    country_id: z.coerce.number().min(1, 'El país es obligatorio'),
+    age: z.coerce.number().min(18, 'La edad mínima es 18 años'),
+    phone: z
+        .string()
+        .min(10, 'El teléfono debe tener al menos 10 dígitos')
+        .refine((val) => validatePhoneLength(val), {
+            message: 'El teléfono debe tener entre 7 y 11 dígitos.',
+        }),
+    stake_id: z.coerce.number().min(1, 'La estaca/distrito/misión es obligatoria'),
+    referrer_name: z.string().min(1, 'Tu nombre es obligatorio'),
+    referrer_phone: z
+        .string()
+        .min(1, 'Tu teléfono es obligatorio')
+        .refine((val) => validatePhoneLength(val), {
+            message: 'El teléfono debe tener entre 7 y 11 dígitos.',
+        }),
+    relationship_with_referred: z.coerce.number().min(1, 'La relación con la persona referida es obligatoria'),
 });


### PR DESCRIPTION
This pull request updates phone number validation logic across several schema files to allow for phone numbers with up to 11 digits instead of the previous maximum of 10. The changes ensure consistency in validation rules and error messages for phone fields in the pre-registration and referral forms.

**Phone validation logic updates:**

* Increased the maximum allowed phone number length in `customPhoneValidation` from 10 to 11 digits, updating the function's default parameter and documentation in `custom-phone-validation.ts`. [[1]](diffhunk://#diff-e7c525257b7c34d2a851015c0b9805a0e249f636225c1b62bccb7895242cc8d8L1-R15) [[2]](diffhunk://#diff-e7c525257b7c34d2a851015c0b9805a0e249f636225c1b62bccb7895242cc8d8L30-R27)

**Schema validation updates:**

* Updated the `preRegistrationSchema` and `referralFormSchema` to use the new phone validation logic, changing error messages to reflect the new maximum of 11 digits and updating the `.refine()` checks accordingly. [[1]](diffhunk://#diff-895c07d45283f892850c67c6a4782a26834b58093af1b5e4695aeb9d66774ee1L15-L53) [[2]](diffhunk://#diff-c51df905b4bc8489d739a0eb4417e0e77000a80bfdb767877c0072a6a1f2f3b0L1-R23)

**Code style consistency:**

* Standardized import statements and string quotes to single quotes for consistency in `pre-registration.ts` and `referral.ts`. [[1]](diffhunk://#diff-895c07d45283f892850c67c6a4782a26834b58093af1b5e4695aeb9d66774ee1L1-R2) [[2]](diffhunk://#diff-c51df905b4bc8489d739a0eb4417e0e77000a80bfdb767877c0072a6a1f2f3b0L1-R23)